### PR TITLE
Cleanup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -27,7 +27,7 @@ bl_info = {
     "name": "Clipping Assistant",
     "description": "Assistant to set Viewport and Camera Clipping Distance",
     "author": "Daniel Grauer",
-    "version": (2, 1, 1),
+    "version": (2, 2, 0),
     "blender": (2, 83, 0),
     "location": "TopBar",
     "category": "System",
@@ -158,8 +158,8 @@ def get_clipping(context):
     active_object = context.active_object
 
     if prefs().debug_output:
-        print(f"\nActive object: {active_object.name}")
-        print(f"  Selected objects: {[obj.name for obj in selected_objects]}")
+        print(f"\nActive object: {active_object.name}, type: {active_object.type}")
+        print(f"  Selected objects: {[(obj.name, obj.type) for obj in selected_objects]}")
         
     obj_dimension = [obj.dimensions for obj in selected_objects] if selected_objects else []
     obj_location = [obj.location for obj in selected_objects] if selected_objects else []
@@ -250,7 +250,10 @@ class ClippingAssistant(Operator):
     bl_description = "Start and End Clipping Distance of Camera(s)"
     bl_options = {"REGISTER", "UNDO"}   
 
-    ob_type = ['MESH', 'CURVE', 'SURFACE', 'META', 'FONT', 'HAIR', 'POINTCLOUD', 'VOLUME', 'GPENCIL', 'ARMATURE', 'LATTICE']    
+    ob_type = ['MESH', 'CURVE', 'SURFACE', 'META', 
+               'FONT', 'HAIR', 'POINTCLOUD', 'VOLUME', 
+               'GPENCIL', 'ARMATURE', 'LATTICE', 'EMPTY']
+    
     trigger_event_types = ['BUTTON4MOUSE', 'BUTTON5MOUSE', 'BUTTON6MOUSE', 'BUTTON7MOUSE',
                             'WHEELUPMOUSE', 'WHEELDOWNMOUSE', 'MIDDLEMOUSE',
                            'TRACKPADZOOM', 'TRACKPADPAN', 'MOUSEROTATE', 
@@ -262,7 +265,7 @@ class ClippingAssistant(Operator):
     right_click_event_types = ['LEFTMOUSE', 'RIGHTMOUSE']    
 
     @classmethod
-    def poll(cls, context):      
+    def poll(cls, context):  
         return context.selected_objects or context.active_object
     
     def execute(self, context):
@@ -281,17 +284,17 @@ class ClippingAssistant(Operator):
             clipping_active = True
             # detect the mouse button used for selection, this causes conflicts in certain scenarios when interacting with gizmos with LMB  
             #   0 == LMB, 1 == RMB          
-            active_keymap = bpy.context.preferences.keymap.active_keyconfig
-            
+            active_keymap = bpy.context.preferences.keymap.active_keyconfig            
             preferences = bpy.context.window_manager.keyconfigs[active_keymap].preferences
+
             if 'select_mouse' in preferences:
                 right_click_select = preferences['select_mouse']
             else:
                 right_click_select = None
+
             intersection = set(self.right_click_event_types).intersection(self.trigger_event_types)            
             if intersection: 
-                if right_click_select == 0:                    
-                    #print("intersection: ", intersection) 
+                if right_click_select == 0:                 
                     self.trigger_event_types = set(self.trigger_event_types) - set(intersection)
             else:
                 if right_click_select == 1:

--- a/__init__.py
+++ b/__init__.py
@@ -58,8 +58,9 @@ def min_list_value(input_list):
         so 0 values are ignored to avoid invalid minimum object sizes.
     '''
     filtered_list = [value for value in input_list[0] if value > 0]
-    if filtered_list is None:
-        return None  # Handle case where all values are zero
+    if not filtered_list:
+        # This block runs if filtered_list is empty []
+        return 1 # Or handle the case appropriately
     
     min_value = min(filtered_list)
     return min_value

--- a/__init__.py
+++ b/__init__.py
@@ -408,29 +408,30 @@ def draw_button(self, context):
         
         # Display the clip start and end values
         if clipping_active:
-            try:
-                scene = context.scene
-                unit_settings = scene.unit_settings
-                scale_length = scene.unit_settings.scale_length
+            if prefs().show_clipping_distance:
+                try:                                
+                    scene = context.scene
+                    unit_settings = scene.unit_settings
+                    scale_length = scene.unit_settings.scale_length
 
-                if unit_settings.system == 'METRIC':
-                    scale_length *= 100.0
-                elif unit_settings.system == 'IMPERIAL':
-                    scale_length *= 3.28084
+                    if unit_settings.system == 'METRIC':
+                        scale_length *= 100.0
+                    elif unit_settings.system == 'IMPERIAL':
+                        scale_length *= 3.28084
 
-                clip_start_value = None
-                clip_end_value = None
-                for area in context.screen.areas:
-                    if area.type == 'VIEW_3D':
-                        space = area.spaces.active
-                        clip_start_value = space.clip_start * scale_length
-                        clip_end_value = space.clip_end * scale_length
-                
-                row = layout.row(align=True)
-                row.label(text=f"[{clip_start_value:.2f} | {clip_end_value:.2f}]")
+                    clip_start_value = None
+                    clip_end_value = None
+                    for area in context.screen.areas:
+                        if area.type == 'VIEW_3D':
+                            space = area.spaces.active
+                            clip_start_value = space.clip_start * scale_length
+                            clip_end_value = space.clip_end * scale_length
+                    
+                    row = layout.row(align=True)
+                    row.label(text=f"[{clip_start_value:.2f} | {clip_end_value:.2f}]")
 
-            except (KeyError, IndexError, AttributeError):
-                layout.row(align=True).label(text="Clip: N/A")
+                except (KeyError, IndexError, AttributeError):
+                    layout.row(align=True).label(text="Clip: N/A")
                 
         row.operator(
             operator="scene.clipping_assistant", 

--- a/__init__.py
+++ b/__init__.py
@@ -53,16 +53,16 @@ def max_list_value(input_list):
 
 
 def min_list_value(input_list):
-    ''' Return the minimum non-zero value in a list and its index. 
+    ''' Return the minimum non-zero value in a list. 
         Objects can have 0 size in certain dimensions (e.g., planes or edges), 
         so 0 values are ignored to avoid invalid minimum object sizes.
     '''
     filtered_list = [value for value in input_list[0] if value > 0]
     if filtered_list is None:
-        return None, None  # Handle case where all values are zero
+        return None  # Handle case where all values are zero
+    
     min_value = min(filtered_list)
-    min_index = input_list[0].index(min_value)
-    return min_index, min_value
+    return min_value
 
 
 def apply_clipping(context):

--- a/preferences.py
+++ b/preferences.py
@@ -82,17 +82,17 @@ class ClippingAssistant_Preferences(AddonPreferences):
         name="Apply Clipping To Volumetrics",
         description="Adapt Clipping distances of volumetric effects",
         default=True)
+    
+    debug_output: BoolProperty(
+        name="Debug: Output",
+        description="Enable some debug output",
+        default=False) #default=False
         
     debug_profiling: BoolProperty(
         name="Debug: Profiling",
         description="Enable some performance output",
         default=False) #default=False
     
-    debug_output: BoolProperty(
-        name="Debug: Output",
-        description="Enable some debug output",
-        default=True) #default=False
-
 
     def draw(self, context):
         layout = self.layout

--- a/preferences.py
+++ b/preferences.py
@@ -102,6 +102,7 @@ class ClippingAssistant_Preferences(AddonPreferences):
         layout.prop(self, 'camera_clipping')
         layout.prop(self, 'volume_clipping')
         layout.prop(self, 'auto_clipping')
+        layout.prop(self, 'use_object_scale')
 
         # Clipping settings
         column = layout.box()
@@ -114,6 +115,4 @@ class ClippingAssistant_Preferences(AddonPreferences):
         debug_box.label(text="Debug Settings")
         debug_box.prop(self, 'debug_output')
         debug_box.prop(self, 'debug_profiling')
-        if self.debug_profiling:
-            debug_box.prop(self, 'use_object_scale')
 

--- a/preferences.py
+++ b/preferences.py
@@ -85,26 +85,35 @@ class ClippingAssistant_Preferences(AddonPreferences):
         
     debug_profiling: BoolProperty(
         name="Debug: Profiling",
-        description="enable some performance output for debuggung",
-        default=True) #default=False
+        description="Enable some performance output",
+        default=False) #default=False
     
+    debug_output: BoolProperty(
+        name="Debug: Output",
+        description="Enable some debug output",
+        default=True) #default=False
+
 
     def draw(self, context):
         layout = self.layout
-        layout.use_property_split = False        
-        layout.prop(self, 'camera_clipping') 
-        layout.prop(self, 'volume_clipping') 
-        
-        layout.prop(self, 'auto_clipping') 
-        column = layout.box()
-        if self.auto_clipping:
-            column.prop(self, 'clip_start_factor', slider=True)
-            column.prop(self, 'clip_end_factor', slider=True)
-        else:
-            column.prop(self, 'clip_start_distance', slider=True)
-            column.prop(self, 'clip_end_distance', slider=True)
+        layout.use_property_split = False
 
-        layout.prop(self, 'debug_profiling') 
+        # General settings
+        layout.prop(self, 'camera_clipping')
+        layout.prop(self, 'volume_clipping')
+        layout.prop(self, 'auto_clipping')
+
+        # Clipping settings
+        column = layout.box()
+        props = ('clip_start_factor', 'clip_end_factor') if self.auto_clipping else ('clip_start_distance', 'clip_end_distance')
+        for prop in props:
+            column.prop(self, prop, slider=True)
+
+        # Debug settings
+        debug_box = layout.box()
+        debug_box.label(text="Debug Settings")
+        debug_box.prop(self, 'debug_output')
+        debug_box.prop(self, 'debug_profiling')
         if self.debug_profiling:
-            layout.prop(self, 'use_object_scale') 
+            debug_box.prop(self, 'use_object_scale')
 

--- a/preferences.py
+++ b/preferences.py
@@ -91,8 +91,7 @@ class ClippingAssistant_Preferences(AddonPreferences):
     show_clipping_distance: BoolProperty(
         name="Show Clipping Distance",
         description="Show the current clipping distance in the header",
-        default=False
-    )
+        default=True) #default=True
     
 
     def draw(self, context):

--- a/preferences.py
+++ b/preferences.py
@@ -28,11 +28,6 @@ class ClippingAssistant_Preferences(AddonPreferences):
         description="Adjust clipping distance automaticly on selected context",
         default=True) #dfault: True
     
-    use_object_scale: BoolProperty(
-        name="Use Object Scale",
-        description="Use the object scale in the clipping distance calculation",
-        default=False) #dfault: False
-
     clip_start_factor: FloatProperty(
         name="Clip Start Multiplier",
         description="Value to calculate Clip Start, the higher the value the smaller the Clip Start Distance",
@@ -86,7 +81,7 @@ class ClippingAssistant_Preferences(AddonPreferences):
     debug_output: BoolProperty(
         name="Debug: Output",
         description="Enable some debug output",
-        default=False) #default=False
+        default=True) #default=False
         
     debug_profiling: BoolProperty(
         name="Debug: Profiling",
@@ -102,7 +97,6 @@ class ClippingAssistant_Preferences(AddonPreferences):
         layout.prop(self, 'camera_clipping')
         layout.prop(self, 'volume_clipping')
         layout.prop(self, 'auto_clipping')
-        layout.prop(self, 'use_object_scale')
 
         # Clipping settings
         column = layout.box()

--- a/preferences.py
+++ b/preferences.py
@@ -81,12 +81,18 @@ class ClippingAssistant_Preferences(AddonPreferences):
     debug_output: BoolProperty(
         name="Debug: Output",
         description="Enable some debug output",
-        default=True) #default=False
+        default=False) #default=False
         
     debug_profiling: BoolProperty(
         name="Debug: Profiling",
         description="Enable some performance output",
         default=False) #default=False
+    
+    show_clipping_distance: BoolProperty(
+        name="Show Clipping Distance",
+        description="Show the current clipping distance in the header",
+        default=True
+    )
     
 
     def draw(self, context):
@@ -107,6 +113,7 @@ class ClippingAssistant_Preferences(AddonPreferences):
         # Debug settings
         debug_box = layout.box()
         debug_box.label(text="Debug Settings")
+        debug_box.prop(self, 'show_clipping_distance')
         debug_box.prop(self, 'debug_output')
         debug_box.prop(self, 'debug_profiling')
 

--- a/preferences.py
+++ b/preferences.py
@@ -1,0 +1,110 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+from bpy.types import AddonPreferences
+from bpy.props import BoolProperty, IntProperty, FloatProperty, EnumProperty, StringProperty, PointerProperty, CollectionProperty
+
+
+class ClippingAssistant_Preferences(AddonPreferences):
+    bl_idname = __package__
+
+    auto_clipping: BoolProperty(
+        name="Auto Clipping",
+        description="Adjust clipping distance automaticly on selected context",
+        default=True) #dfault: True
+    
+    use_object_scale: BoolProperty(
+        name="Use Object Scale",
+        description="Use the object scale in the clipping distance calculation",
+        default=False) #dfault: False
+
+    clip_start_factor: FloatProperty(
+        name="Clip Start Multiplier",
+        description="Value to calculate Clip Start, the higher the value the smaller the Clip Start Distance",
+        default=0.01,
+        min = 0.001,
+        soft_min = 1,
+        soft_max=10,
+        step=1,
+        subtype='FACTOR') 
+
+    clip_end_factor: FloatProperty(
+        name="Clip End Multiplier",
+        description="Value to calculate Clip End, the higher the value the bigger the Clip End Distance",
+        default=10,
+        min = 0.001,
+        soft_min = 1,
+        soft_max=100,
+        step=1,
+        subtype='FACTOR')
+
+    clip_start_distance: FloatProperty(
+        name="Clip Start Distance",
+        description="Set the Clip Start distance",
+        default=0.001,
+        min=0.000001, 
+        soft_min = 0.0001,
+        soft_max=0.01,
+        step=1,
+        subtype='DISTANCE') 
+
+    clip_end_distance: FloatProperty(
+        name="Clip End Distance",
+        description="Set the Clip End distance",
+        default=100,
+        min = 0.01,
+        soft_min = 0.01,
+        soft_max=200,
+        step=1,
+        subtype='DISTANCE') 
+
+    camera_clipping: BoolProperty(
+        name="Apply Clipping To Active Camera",
+        description="When enabled the clipping Distance of the Active Camera is adjusted as well as the Viewport Clip Distance",
+        default=False)
+
+    volume_clipping: BoolProperty(
+        name="Apply Clipping To Volumetrics",
+        description="Adapt Clipping distances of volumetric effects",
+        default=True)
+        
+    debug_profiling: BoolProperty(
+        name="Debug: Profiling",
+        description="enable some performance output for debuggung",
+        default=True) #default=False
+    
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = False        
+        layout.prop(self, 'camera_clipping') 
+        layout.prop(self, 'volume_clipping') 
+        
+        layout.prop(self, 'auto_clipping') 
+        column = layout.box()
+        if self.auto_clipping:
+            column.prop(self, 'clip_start_factor', slider=True)
+            column.prop(self, 'clip_end_factor', slider=True)
+        else:
+            column.prop(self, 'clip_start_distance', slider=True)
+            column.prop(self, 'clip_end_distance', slider=True)
+
+        layout.prop(self, 'debug_profiling') 
+        if self.debug_profiling:
+            layout.prop(self, 'use_object_scale') 
+

--- a/preferences.py
+++ b/preferences.py
@@ -62,7 +62,7 @@ class ClippingAssistant_Preferences(AddonPreferences):
     debug_output: BoolProperty(
         name="Debug: Output",
         description="Enable some debug output",
-        default=True) #default=False
+        default=False) #default=False
         
     debug_profiling: BoolProperty(
         name="Debug: Profiling",

--- a/preferences.py
+++ b/preferences.py
@@ -28,25 +28,6 @@ class ClippingAssistant_Preferences(AddonPreferences):
         description="Adjust clipping distance automaticly on selected context",
         default=True) #dfault: True
     
-    clip_start_factor: FloatProperty(
-        name="Clip Start Multiplier",
-        description="Value to calculate Clip Start, the higher the value the smaller the Clip Start Distance",
-        default=0.01,
-        min = 0.001,
-        soft_min = 1,
-        soft_max=10,
-        step=1,
-        subtype='FACTOR') 
-
-    clip_end_factor: FloatProperty(
-        name="Clip End Multiplier",
-        description="Value to calculate Clip End, the higher the value the bigger the Clip End Distance",
-        default=10,
-        min = 0.001,
-        soft_min = 1,
-        soft_max=100,
-        step=1,
-        subtype='FACTOR')
 
     clip_start_distance: FloatProperty(
         name="Clip Start Distance",
@@ -81,7 +62,7 @@ class ClippingAssistant_Preferences(AddonPreferences):
     debug_output: BoolProperty(
         name="Debug: Output",
         description="Enable some debug output",
-        default=False) #default=False
+        default=True) #default=False
         
     debug_profiling: BoolProperty(
         name="Debug: Profiling",
@@ -91,7 +72,7 @@ class ClippingAssistant_Preferences(AddonPreferences):
     show_clipping_distance: BoolProperty(
         name="Show Clipping Distance",
         description="Show the current clipping distance in the header",
-        default=True) #default=True
+        default=True) #default=False
     
 
     def draw(self, context):
@@ -104,10 +85,10 @@ class ClippingAssistant_Preferences(AddonPreferences):
         layout.prop(self, 'auto_clipping')
 
         # Clipping settings
-        column = layout.box()
-        props = ('clip_start_factor', 'clip_end_factor') if self.auto_clipping else ('clip_start_distance', 'clip_end_distance')
-        for prop in props:
-            column.prop(self, prop, slider=True)
+        if not self.auto_clipping:  
+            column = layout.box()      
+            column.prop(self, 'clip_start_distance', slider=True)
+            column.prop(self, 'clip_end_distance', slider=True)
 
         # Debug settings
         debug_box = layout.box()

--- a/preferences.py
+++ b/preferences.py
@@ -17,7 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 from bpy.types import AddonPreferences
-from bpy.props import BoolProperty, IntProperty, FloatProperty, EnumProperty, StringProperty, PointerProperty, CollectionProperty
+from bpy.props import BoolProperty, FloatProperty
 
 
 class ClippingAssistant_Preferences(AddonPreferences):
@@ -76,7 +76,7 @@ class ClippingAssistant_Preferences(AddonPreferences):
     volume_clipping: BoolProperty(
         name="Apply Clipping To Volumetrics",
         description="Adapt Clipping distances of volumetric effects",
-        default=True)
+        default=False)
     
     debug_output: BoolProperty(
         name="Debug: Output",
@@ -91,7 +91,7 @@ class ClippingAssistant_Preferences(AddonPreferences):
     show_clipping_distance: BoolProperty(
         name="Show Clipping Distance",
         description="Show the current clipping distance in the header",
-        default=True
+        default=False
     )
     
 


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Clipping Assistant addon by externalizing preferences, consolidating helper logic, rewriting the clipping workflow, enhancing operator event handling and UI redraw, adding live display of clipping distances in the header, and bumping the version to 2.2.0.

New Features:
- Show current viewport clipping distances in the Top Bar header with unit conversion.

Enhancements:
- Extract AddonPreferences into a separate preferences.py module and add caching for prefs() access.
- Modularize and rename helper functions for object dimension, location, and clipping min/max calculations.
- Overhaul apply_clipping and calculate_clipping to handle no-object scenarios, integrate profiling and debug output, and simplify area/space traversal.
- Extend operator trigger events with additional mouse buttons and key modifiers, and improve Top Bar redraw via header tagging and frame_set hack.

Build:
- Bump addon version to 2.2.0 in bl_info.